### PR TITLE
Add portfolio hook and integrate into Home screen

### DIFF
--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -8,6 +8,7 @@ import { Svg, Defs, LinearGradient as SvgLinearGradient, Stop, Path } from "reac
 import { useNavigation } from "@react-navigation/native"; 
 import Button from "../components/ui/Button";
 import RevolutCardsWidget, { CardData } from "../components/RevolutCardsWidget";
+import { usePortfolio } from "../store/portfolio";
 
 // Types
 type User = { id: string; firstName: string; lastName: string };
@@ -45,6 +46,8 @@ export default function Home() {
     { id: "t2", merchant: "Thomas Francis", createdAt: new Date(Date.now() - 2 * 86400000).toISOString(), status: "Sent from Revolut", amount: -18 },
   ];
   const recentTransactions = useMemo(() => transactions.slice(0, 2), [transactions]);
+  const { cash, crypto, invest } = usePortfolio();
+  const totalWealth = cash + crypto + invest;
   const balance = 2.19;
   const [whole, cents] = balance.toFixed(2).split(".");
   const cards: CardData[] = [
@@ -159,12 +162,12 @@ export default function Home() {
             <ChevronRight size={16} color="rgba(255,255,255,0.55)" />
           </View>
           <View style={styles.card}>
-            <Text style={styles.bigNumber}>{formatAUD(4.29)}</Text>
+            <Text style={styles.bigNumber}>{formatAUD(totalWealth)}</Text>
             <View style={{ marginTop: 16, gap: 16 }}>
-              <Row iconBg="#6C8CFF" left="Cash" right={formatAUD(2.19)} />
-              <Row iconBg="#A070FF" left="Crypto" right={formatAUD(2.10)} iconText="₿" />
+              <Row iconBg="#6C8CFF" left="Cash" right={formatAUD(cash)} />
+              <Row iconBg="#A070FF" left="Crypto" right={formatAUD(crypto)} iconText="₿" />
               <RowChevron iconBg="#D8E958" title="Loan" subtitle="Get a low-rate loan up to $50,000" />
-              <RowChevron iconBg="#56B4FF" title="Invest" subtitle="Invest for as little as $1" icon={<BarChart3 size={16} color="#fff" />} />
+              <Row iconBg="#56B4FF" left="Invest" right={formatAUD(invest)} icon={<BarChart3 size={16} color="#fff" />} />
             </View>
           </View>
 
@@ -217,12 +220,12 @@ export default function Home() {
 }
 
 // Small row components
-function Row({ iconBg, left, right, iconText }: { iconBg: string; left: string; right: string; iconText?: string }) {
+function Row({ iconBg, left, right, iconText, icon }: { iconBg: string; left: string; right: string; iconText?: string; icon?: React.ReactNode }) {
   return (
     <View style={styles.row}>
       <View style={styles.rowLeft}>
         <View style={[styles.rowIcon, { backgroundColor: iconBg }]}>
-          <Text style={styles.rowIconText}>{iconText ?? "$"}</Text>
+          {icon ? icon : <Text style={styles.rowIconText}>{iconText ?? "$"}</Text>}
         </View>
         <Text style={styles.rowLeftText}>{left}</Text>
       </View>

--- a/src/store/portfolio.ts
+++ b/src/store/portfolio.ts
@@ -1,0 +1,22 @@
+import React, { createContext, useContext } from "react";
+
+export type Portfolio = {
+  cash: number;
+  crypto: number;
+  invest: number;
+};
+
+const PortfolioContext = createContext<Portfolio>({
+  cash: 2.19,
+  crypto: 2.1,
+  invest: 0,
+});
+
+export function usePortfolio() {
+  return useContext(PortfolioContext);
+}
+
+export const PortfolioProvider = ({ children }: { children: React.ReactNode }) => {
+  const value = { cash: 2.19, crypto: 2.1, invest: 0 };
+  return React.createElement(PortfolioContext.Provider, { value }, children);
+};


### PR DESCRIPTION
## Summary
- add portfolio store with usePortfolio hook for cash, crypto and invest balances
- compute total wealth from portfolio in Home screen
- show Cash, Crypto and Invest rows driven by store values

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac5f11cc83239e3758ab470d7e44