### PR TITLE
Add portfolio store and wire balance actions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import Transactions from "./src/screens/Transactions";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { TrendingUp, Home as HomeIcon, ArrowRightLeft, Bitcoin } from "lucide-react-native";
 import { useColorScheme } from "react-native";
+import { PortfolioProvider } from "./src/store/portfolio";
 export type RootStackParamList = {
   Tabs: undefined;
   Transactions: undefined;
@@ -74,14 +75,16 @@ function Tabs() {
 export default function App() {
   const scheme = useColorScheme();
   return (
-    <QueryClientProvider client={queryClient}>
-      <NavigationContainer theme={scheme === "dark" ? DarkTheme : DefaultTheme}>
-        <StatusBar style="light" />
-        <Stack.Navigator initialRouteName="Tabs" screenOptions={{ headerShown: false, animation: "fade" }}>
-          <Stack.Screen name="Tabs" component={Tabs} />
-          <Stack.Screen name="Transactions" component={Transactions} />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </QueryClientProvider>
+    <PortfolioProvider>
+      <QueryClientProvider client={queryClient}>
+        <NavigationContainer theme={scheme === "dark" ? DarkTheme : DefaultTheme}>
+          <StatusBar style="light" />
+          <Stack.Navigator initialRouteName="Tabs" screenOptions={{ headerShown: false, animation: "fade" }}>
+            <Stack.Screen name="Tabs" component={Tabs} />
+            <Stack.Screen name="Transactions" component={Transactions} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </QueryClientProvider>
+    </PortfolioProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-svg": "15.11.2",
-        "react-native-web": "^0.20.0"
+        "react-native-web": "^0.20.0",
+        "zustand": "^5.0.2"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -8400,6 +8401,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.2.tgz",
+      "integrity": "sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
-    "react-native-web": "^0.20.0"
+    "react-native-web": "^0.20.0",
+    "zustand": "^5.0.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/screens/Crypto.tsx
+++ b/src/screens/Crypto.tsx
@@ -13,10 +13,13 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import Svg, { Path } from "react-native-svg";
 import { Search, BarChart2, Globe } from "lucide-react-native";
+import { usePortfolio } from "../store/portfolio";
 
 const { width } = Dimensions.get("window");
 
 export default function Crypto() {
+  const balance = usePortfolio((s) => s.crypto);
+  const tradeCrypto = usePortfolio((s) => s.tradeCrypto);
   return (
     <SafeAreaView style={styles.container}>
       <LinearGradient colors={["#9333ea", "#2563eb", "#1e40af"]} style={styles.gradient}>
@@ -40,7 +43,7 @@ export default function Crypto() {
 
           {/* Balance Section */}
           <View style={styles.balanceSection}>
-            <Text style={styles.balanceAmount}>$5.85</Text>
+            <Text style={styles.balanceAmount}>${balance.toFixed(2)}</Text>
             <Text style={styles.balanceChange}>+$1.13 • +24.17%</Text>
           </View>
 // ...existing code...
@@ -55,7 +58,7 @@ export default function Crypto() {
           {/* Action Buttons */}
           <View style={styles.actionButtons}>
             <View style={styles.actionButton}>
-              <TouchableOpacity style={styles.actionButtonCircle}>
+              <TouchableOpacity style={styles.actionButtonCircle} onPress={() => tradeCrypto(1)}>
                 <Text style={styles.actionButtonIcon}>📈</Text>
               </TouchableOpacity>
               <Text style={styles.actionButtonText}>Trade</Text>

--- a/src/screens/Invest.tsx
+++ b/src/screens/Invest.tsx
@@ -3,21 +3,25 @@ import { View, Text, TextInput, TouchableOpacity, ScrollView, StyleSheet, Status
 import Svg, { Path } from "react-native-svg";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Search, TrendingUp, Plus, ArrowDown, MoreHorizontal, ChevronUp, ChevronRight, BarChart2, Globe } from "lucide-react-native";
-import { 
+import {
   FinancialCard,
-  MostTradedWidget, 
-  ProductsWidget, 
-  TopMoversWidget, 
+  MostTradedWidget,
+  ProductsWidget,
+  TopMoversWidget,
   TransactionsWidget,
   ThemeProvider,
   type StockItem,
   type TradedStock,
   type Stock,
-  type Transaction 
+  type Transaction
 } from '../components/widgets';
+import { usePortfolio } from "../store/portfolio";
 
 export default function Invest() {
   const { width } = Dimensions.get("window");
+  const investBalance = usePortfolio((s) => s.invest);
+  const changeInvest = usePortfolio((s) => s.changeInvest);
+  const [dollars, cents] = investBalance.toFixed(2).split(".");
 
   // Sample data for widgets
   const stockItems: StockItem[] = [
@@ -134,8 +138,8 @@ export default function Invest() {
           <View style={styles.portfolioSection}>
             <Text style={styles.portfolioLabel}>Capital at risk</Text>
             <View style={styles.portfolioValue}>
-              <Text style={styles.portfolioAmount}>$6</Text>
-              <Text style={styles.portfolioCents}>.74</Text>
+              <Text style={styles.portfolioAmount}>${dollars}</Text>
+              <Text style={styles.portfolioCents}>.{cents}</Text>
             </View>
             <View style={styles.portfolioChange}>
               <Text style={styles.changeText}>+$0.02</Text>
@@ -152,19 +156,19 @@ export default function Invest() {
 
           {/* Action Buttons */}
           <View style={styles.actionButtons}>
-            <TouchableOpacity style={[styles.actionButton, { width: (width - 8 * 2 - 8 * 3) / 4 }]}>
+            <TouchableOpacity style={[styles.actionButton, { width: (width - 8 * 2 - 8 * 3) / 4 }]} onPress={() => changeInvest(1)}>
               <View style={styles.actionButtonIcon}>
                 <TrendingUp size={20} color="white" />
               </View>
               <Text style={styles.actionButtonText}>Trade</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.actionButton, { width: (width - 8 * 2 - 8 * 3) / 4 }]}>
+            <TouchableOpacity style={[styles.actionButton, { width: (width - 8 * 2 - 8 * 3) / 4 }]} onPress={() => changeInvest(1)}>
               <View style={styles.actionButtonIcon}>
                 <Plus size={20} color="white" />
               </View>
               <Text style={styles.actionButtonText}>Add money</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={[styles.actionButton, { width: (width - 8 * 2 - 8 * 3) / 4 }]}>
+            <TouchableOpacity style={[styles.actionButton, { width: (width - 8 * 2 - 8 * 3) / 4 }]} onPress={() => changeInvest(-1)}>
               <View style={styles.actionButtonIcon}>
                 <ArrowDown size={20} color="white" />
               </View>

--- a/src/store/portfolio.ts
+++ b/src/store/portfolio.ts
@@ -25,8 +25,14 @@ const usePortfolioStore = create<PortfolioState & PortfolioActions>((set) => ({
   ...initialState,
   addCash: (amount) => set((state) => ({ cash: state.cash + amount })),
   withdrawCash: (amount) => set((state) => ({ cash: state.cash - amount })),
-  tradeCrypto: (delta) => set((state) => ({ crypto: state.crypto + delta })),
-  changeInvest: (delta) => set((state) => ({ invest: state.invest + delta })),
+  tradeCrypto: (delta) => set((state) => {
+    const newCrypto = state.crypto + delta;
+    return newCrypto >= 0 ? { crypto: newCrypto } : {};
+  }),
+  changeInvest: (delta) => set((state) => {
+    const newInvest = state.invest + delta;
+    return newInvest >= 0 ? { invest: newInvest } : {};
+  }),
 }));
 
 // Context wrapper so components can access via provider if needed

--- a/src/store/portfolio.ts
+++ b/src/store/portfolio.ts
@@ -24,7 +24,11 @@ const initialState: PortfolioState = {
 const usePortfolioStore = create<PortfolioState & PortfolioActions>((set) => ({
   ...initialState,
   addCash: (amount) => set((state) => ({ cash: state.cash + amount })),
-  withdrawCash: (amount) => set((state) => ({ cash: state.cash - amount })),
+  withdrawCash: (amount) => set((state) => (
+    state.cash >= amount
+      ? { cash: state.cash - amount }
+      : { cash: state.cash }
+  )),
   tradeCrypto: (delta) => set((state) => {
     const newCrypto = state.crypto + delta;
     return newCrypto >= 0 ? { crypto: newCrypto } : {};

--- a/src/store/portfolio.ts
+++ b/src/store/portfolio.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+import React, { createContext, useContext, ReactNode } from 'react';
+
+export type PortfolioState = {
+  cash: number;
+  crypto: number;
+  invest: number;
+};
+
+export type PortfolioActions = {
+  addCash: (amount: number) => void;
+  withdrawCash: (amount: number) => void;
+  tradeCrypto: (delta: number) => void;
+  changeInvest: (delta: number) => void;
+};
+
+const initialState: PortfolioState = {
+  cash: 0,
+  crypto: 5.85,
+  invest: 6.74,
+};
+
+// Create the Zustand store
+const usePortfolioStore = create<PortfolioState & PortfolioActions>((set) => ({
+  ...initialState,
+  addCash: (amount) => set((state) => ({ cash: state.cash + amount })),
+  withdrawCash: (amount) => set((state) => ({ cash: state.cash - amount })),
+  tradeCrypto: (delta) => set((state) => ({ crypto: state.crypto + delta })),
+  changeInvest: (delta) => set((state) => ({ invest: state.invest + delta })),
+}));
+
+// Context wrapper so components can access via provider if needed
+const StoreContext = createContext<typeof usePortfolioStore | null>(null);
+
+export function PortfolioProvider({ children }: { children: ReactNode }) {
+  return React.createElement(StoreContext.Provider, { value: usePortfolioStore }, children);
+}
+
+export function usePortfolio<T>(selector: (state: PortfolioState & PortfolioActions) => T): T {
+  const store = useContext(StoreContext);
+  if (!store) {
+    throw new Error('usePortfolio must be used within a PortfolioProvider');
+  }
+  return store(selector);
+}
+
+export { usePortfolioStore };


### PR DESCRIPTION
## Summary
- add Zustand portfolio store with cash, crypto and invest balances
- wrap app with portfolio provider
- use store selectors for crypto and invest balances and wire trade/add/withdraw actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68c5ac73ac708323a53d9618b6ea9921