### PR TITLE
feat: simulate portfolio market shifts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { NavigationContainer, DefaultTheme, DarkTheme } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PortfolioProvider } from "./src/store/portfolio";
 import Home from "./src/screens/Home";
 import Invest from "./src/screens/Invest";
 import Payments from "./src/screens/Payments";
@@ -75,13 +76,15 @@ export default function App() {
   const scheme = useColorScheme();
   return (
     <QueryClientProvider client={queryClient}>
-      <NavigationContainer theme={scheme === "dark" ? DarkTheme : DefaultTheme}>
-        <StatusBar style="light" />
-        <Stack.Navigator initialRouteName="Tabs" screenOptions={{ headerShown: false, animation: "fade" }}>
-          <Stack.Screen name="Tabs" component={Tabs} />
-          <Stack.Screen name="Transactions" component={Transactions} />
-        </Stack.Navigator>
-      </NavigationContainer>
+      <PortfolioProvider>
+        <NavigationContainer theme={scheme === "dark" ? DarkTheme : DefaultTheme}>
+          <StatusBar style="light" />
+          <Stack.Navigator initialRouteName="Tabs" screenOptions={{ headerShown: false, animation: "fade" }}>
+            <Stack.Screen name="Tabs" component={Tabs} />
+            <Stack.Screen name="Transactions" component={Transactions} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </PortfolioProvider>
     </QueryClientProvider>
   );
 }

--- a/src/screens/Crypto.tsx
+++ b/src/screens/Crypto.tsx
@@ -13,10 +13,12 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import Svg, { Path } from "react-native-svg";
 import { Search, BarChart2, Globe } from "lucide-react-native";
+import { usePortfolio } from "../store/portfolio";
 
 const { width } = Dimensions.get("window");
 
 export default function Crypto() {
+  const { crypto } = usePortfolio();
   return (
     <SafeAreaView style={styles.container}>
       <LinearGradient colors={["#9333ea", "#2563eb", "#1e40af"]} style={styles.gradient}>
@@ -40,8 +42,8 @@ export default function Crypto() {
 
           {/* Balance Section */}
           <View style={styles.balanceSection}>
-            <Text style={styles.balanceAmount}>$5.85</Text>
-            <Text style={styles.balanceChange}>+$1.13 • +24.17%</Text>
+            <Text style={styles.balanceAmount}>${crypto.toFixed(2)}</Text>
+            <Text style={styles.balanceChange}>+0.00 • 0%</Text>
           </View>
 // ...existing code...
 

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -8,6 +8,7 @@ import { Svg, Defs, LinearGradient as SvgLinearGradient, Stop, Path } from "reac
 import { useNavigation } from "@react-navigation/native"; 
 import Button from "../components/ui/Button";
 import RevolutCardsWidget, { CardData } from "../components/RevolutCardsWidget";
+import { usePortfolio } from "../store/portfolio";
 
 // Types
 type User = { id: string; firstName: string; lastName: string };
@@ -45,8 +46,11 @@ export default function Home() {
     { id: "t2", merchant: "Thomas Francis", createdAt: new Date(Date.now() - 2 * 86400000).toISOString(), status: "Sent from Revolut", amount: -18 },
   ];
   const recentTransactions = useMemo(() => transactions.slice(0, 2), [transactions]);
-  const balance = 2.19;
+  const { crypto, invest } = usePortfolio();
+  const cash = 2.19;
+  const balance = cash;
   const [whole, cents] = balance.toFixed(2).split(".");
+  const totalWealth = cash + crypto + invest;
   const cards: CardData[] = [
     { id: "original", label: "Original", secondary: "··4103", gradientKey: "original", showAlertDot: true, showMastercard: true, ring: true },
     { id: "disposable", label: "Disposable", secondary: "Generate", gradientKey: "disposable", showMastercard: true },
@@ -159,12 +163,12 @@ export default function Home() {
             <ChevronRight size={16} color="rgba(255,255,255,0.55)" />
           </View>
           <View style={styles.card}>
-            <Text style={styles.bigNumber}>{formatAUD(4.29)}</Text>
+            <Text style={styles.bigNumber}>{formatAUD(totalWealth)}</Text>
             <View style={{ marginTop: 16, gap: 16 }}>
-              <Row iconBg="#6C8CFF" left="Cash" right={formatAUD(2.19)} />
-              <Row iconBg="#A070FF" left="Crypto" right={formatAUD(2.10)} iconText="₿" />
+              <Row iconBg="#6C8CFF" left="Cash" right={formatAUD(cash)} />
+              <Row iconBg="#A070FF" left="Crypto" right={formatAUD(crypto)} iconText="₿" />
+              <Row iconBg="#56B4FF" left="Invest" right={formatAUD(invest)} icon={<BarChart3 size={16} color="#fff" />} />
               <RowChevron iconBg="#D8E958" title="Loan" subtitle="Get a low-rate loan up to $50,000" />
-              <RowChevron iconBg="#56B4FF" title="Invest" subtitle="Invest for as little as $1" icon={<BarChart3 size={16} color="#fff" />} />
             </View>
           </View>
 
@@ -217,12 +221,24 @@ export default function Home() {
 }
 
 // Small row components
-function Row({ iconBg, left, right, iconText }: { iconBg: string; left: string; right: string; iconText?: string }) {
+function Row({
+  iconBg,
+  left,
+  right,
+  iconText,
+  icon,
+}: {
+  iconBg: string;
+  left: string;
+  right: string;
+  iconText?: string;
+  icon?: React.ReactNode;
+}) {
   return (
     <View style={styles.row}>
       <View style={styles.rowLeft}>
         <View style={[styles.rowIcon, { backgroundColor: iconBg }]}>
-          <Text style={styles.rowIconText}>{iconText ?? "$"}</Text>
+          {icon ?? <Text style={styles.rowIconText}>{iconText ?? "$"}</Text>}
         </View>
         <Text style={styles.rowLeftText}>{left}</Text>
       </View>

--- a/src/screens/Invest.tsx
+++ b/src/screens/Invest.tsx
@@ -3,21 +3,23 @@ import { View, Text, TextInput, TouchableOpacity, ScrollView, StyleSheet, Status
 import Svg, { Path } from "react-native-svg";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Search, TrendingUp, Plus, ArrowDown, MoreHorizontal, ChevronUp, ChevronRight, BarChart2, Globe } from "lucide-react-native";
-import { 
+import {
   FinancialCard,
-  MostTradedWidget, 
-  ProductsWidget, 
-  TopMoversWidget, 
+  MostTradedWidget,
+  ProductsWidget,
+  TopMoversWidget,
   TransactionsWidget,
   ThemeProvider,
   type StockItem,
   type TradedStock,
   type Stock,
-  type Transaction 
+  type Transaction
 } from '../components/widgets';
+import { usePortfolio } from "../store/portfolio";
 
 export default function Invest() {
   const { width } = Dimensions.get("window");
+  const { invest } = usePortfolio();
 
   // Sample data for widgets
   const stockItems: StockItem[] = [
@@ -107,6 +109,8 @@ export default function Invest() {
     }
   ];
 
+  const [whole, cents] = invest.toFixed(2).split(".");
+
   return (
     <ThemeProvider>
       <SafeAreaView style={styles.container} edges={["top"]}>
@@ -134,12 +138,12 @@ export default function Invest() {
           <View style={styles.portfolioSection}>
             <Text style={styles.portfolioLabel}>Capital at risk</Text>
             <View style={styles.portfolioValue}>
-              <Text style={styles.portfolioAmount}>$6</Text>
-              <Text style={styles.portfolioCents}>.74</Text>
+              <Text style={styles.portfolioAmount}>${whole}</Text>
+              <Text style={styles.portfolioCents}>.{cents}</Text>
             </View>
             <View style={styles.portfolioChange}>
-              <Text style={styles.changeText}>+$0.02</Text>
-              <Text style={styles.changeText}>▲ 0.23%</Text>
+              <Text style={styles.changeText}>+$0.00</Text>
+              <Text style={styles.changeText}>▲ 0.00%</Text>
             </View>
           </View>
 
@@ -183,7 +187,7 @@ export default function Invest() {
             <FinancialCard
               icon={<TrendingUp size={20} color="white" />}
               title="Stocks"
-              price="$6.74"
+              price={`$${invest.toFixed(2)}`}
               change="▲ 0.23%"
               isPositive={true}
               stocks={stockItems}

--- a/src/store/portfolio.tsx
+++ b/src/store/portfolio.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
+
+export type Portfolio = {
+  crypto: number;
+  invest: number;
+};
+
+export type PortfolioContextType = Portfolio & {
+  applyDelta: (delta: Partial<Portfolio>) => void;
+};
+
+const PortfolioContext = createContext<PortfolioContextType | undefined>(undefined);
+
+export const PortfolioProvider = ({ children }: { children: ReactNode }) => {
+  const [portfolio, setPortfolio] = useState<Portfolio>({ crypto: 2.1, invest: 6.74 });
+
+  const applyDelta = useCallback((delta: Partial<Portfolio>) => {
+    setPortfolio(prev => ({
+      crypto: prev.crypto + (delta.crypto ?? 0),
+      invest: prev.invest + (delta.invest ?? 0),
+    }));
+  }, []);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      applyDelta({
+        crypto: (Math.random() - 0.5) * 0.1,
+        invest: (Math.random() - 0.5) * 0.1,
+      });
+    }, 5000);
+    return () => clearInterval(id);
+  }, [applyDelta]);
+
+  return (
+    <PortfolioContext.Provider value={{ ...portfolio, applyDelta }}>
+      {children}
+    </PortfolioContext.Provider>
+  );
+};
+
+export const usePortfolio = () => {
+  const ctx = useContext(PortfolioContext);
+  if (!ctx) throw new Error("usePortfolio must be used within PortfolioProvider");
+  return ctx;
+};
+


### PR DESCRIPTION
## Summary
- add portfolio store with periodic random deltas and manual applyDelta helper
- wrap app with portfolio provider and use values across Home, Crypto, and Invest screens
- compute total wealth and show live crypto/invest balances

## Testing
- `npm test` (fails: Missing script)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68c5ac77a7bc83239bfd50e2ac733f74