### PR TITLE
Fix JSX comment in Crypto screen

### DIFF
--- a/src/screens/Crypto.tsx
+++ b/src/screens/Crypto.tsx
@@ -46,7 +46,6 @@ export default function Crypto() {
             <Text style={styles.balanceAmount}>${balance.toFixed(2)}</Text>
             <Text style={styles.balanceChange}>+$1.13 • +24.17%</Text>
           </View>
-// ...existing code...
 
           {/* Chart */}
           <View style={styles.chartContainer}>


### PR DESCRIPTION
## Summary
- remove the stray line comment near the Crypto balance section so the JSX parses correctly

## Testing
- `npm start -- --non-interactive`


------
https://chatgpt.com/codex/tasks/task_e_68cad27c4b2883238f2206074e179f1e